### PR TITLE
Activity id incorrectly typed as int when it should be long on BestEf…

### DIFF
--- a/StravaDotNet/Activities/BestEffortForActivity.cs
+++ b/StravaDotNet/Activities/BestEffortForActivity.cs
@@ -12,6 +12,6 @@ namespace Strava.Activities
         /// Gets or sets activity id
         /// </summary>
         [JsonProperty("id")]
-        public int Id { get; set; }
+        public long Id { get; set; }
     }
 }


### PR DESCRIPTION
…fortForActivity. This started throwing exceptions as of today as Strava's activity id's incremented over the max size for a 32 int

If you are still maintaining your Nuget package would be great to get this pushed in. Errors started occurring today as Strava's activity id's incremented above the max size for an int