### PR TITLE
Update to Activity Summary after some errors today

### DIFF
--- a/StravaDotNet/Activities/ActivitySummary.cs
+++ b/StravaDotNet/Activities/ActivitySummary.cs
@@ -60,7 +60,7 @@ namespace Strava.Activities
         /// The suffer score.
         /// </summary>
         [JsonProperty("suffer_score")]
-        public int? SufferScore { get; set; }
+        public float? SufferScore { get; set; }
 
         /// <summary>
         /// The token used to embed a Strava activity in the form www.strava.com/activities/[activity_id]/embed/[embed_token].


### PR DESCRIPTION
Looks like Strava may have changed the data type of suffer_score today as my platform started throwing errors. I updated SufferScore to be a float? instead of an it? and it fixed it